### PR TITLE
Allow file upload

### DIFF
--- a/group_vars/reverseproxy
+++ b/group_vars/reverseproxy
@@ -2,3 +2,4 @@ email: "me@something.tld"
 nginx_vhosts:
   - { name: "mydomain.example.com", upstreams: [ "127.0.0.1:8888", "10.1.2.3:4567" ] }
   - { name: "otherone.org", altnames: [ "www.otherone.org", "otherone.com" ], upstreams: [ "10.0.5.12:80" ], hsts: 0, support_websockets: 1 }
+	- { name: "upload.example.com", upstreams: [ "upload.host.xyz" ], client_max_body_size: "400M", client_body_buffer_size: "32K" }

--- a/roles/nginx-letsencrypt-reverseproxy/templates/vhost_ssl.conf.j2
+++ b/roles/nginx-letsencrypt-reverseproxy/templates/vhost_ssl.conf.j2
@@ -1,7 +1,7 @@
 server {
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
-  
+
   server_name "{{ item.name }}"{% if item.altnames is defined %}{% for name in item.altnames %} "{{ name }}"{% endfor %}{% endif %};
 
   include /etc/nginx/global.d/*.conf;
@@ -24,6 +24,11 @@ server {
 {% endif %}
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
+
+{% if item.client_max_body_size is defined %}
+  client_body_buffer_size {{ item.client_body_buffer_size | default('32K') }};
+  client_max_body_size {{ item.client_max_body_size}};
+{% endif %}
 
   location / {
     access_log off;


### PR DESCRIPTION
Hee @UnsignedLong!

Thanks for this Ansible role, it is exactly what i was searching for!

One of my projects requires file uploads, by setting a value for `client_max_body_size` in the `group_vars` file its possible to enable the `client_max_body_size` option. The `client_body_buffer_size` is defaulted to 32K but can be overridden. 

The following example shows a host that accepts file uploads with a max size of 400mb.
```
- { name: "upload.example.com", upstreams: [ "upload.host.xyz" ], client_max_body_size: "400M", client_body_buffer_size: "32K" }
```